### PR TITLE
Fix issue #2

### DIFF
--- a/Assets/HipParticle/Shaders/HipParticle.shader
+++ b/Assets/HipParticle/Shaders/HipParticle.shader
@@ -11,7 +11,7 @@
     SubShader
     {
         Tags { "RenderType" = "Transparent" "Queue"="Transparent+1" }
-        Blend SrcAlpha OneMinusSrcAlpha
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
         ZWrite Off
         LOD 100
 

--- a/Assets/HipParticle/Shaders/HipParticle.shader
+++ b/Assets/HipParticle/Shaders/HipParticle.shader
@@ -38,6 +38,7 @@
             };
             
             sampler2D _Pos;
+            float4 _Pos_TexelSize;
             sampler2D _Col;
             sampler2D _Mag;
             float _Mag_param;
@@ -50,7 +51,7 @@
             
             //テクスチャからfloat値を取り出す
             float3 unpack(float2 uv) {
-                float texWidth = 1024.0;
+                float texWidth = _Pos_TexelSize.z;
                 float2 e = float2(-1.0/texWidth/2, 1.0/texWidth/2);
                 uint3 v0 = uint3(tex2Dlod(_Pos, float4(uv + e.xy,0,0)).xyz * 255.) << 0;
                 uint3 v1 = uint3(tex2Dlod(_Pos, float4(uv + e.yy,0,0)).xyz * 255.) << 8;

--- a/Assets/HipParticle/Textures/color_tex.png.meta
+++ b/Assets/HipParticle/Textures/color_tex.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 9
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0

--- a/Assets/HipParticle/Textures/pos_tex.png.meta
+++ b/Assets/HipParticle/Textures/pos_tex.png.meta
@@ -3,10 +3,10 @@ guid: 186938c8be73e4d20b83a46dff74397f
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 9
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
@@ -21,6 +21,8 @@ TextureImporter:
     heightScale: 0.25
     normalMapFilter: 0
   isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -31,7 +33,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 0
     aniso: -1
-    mipBias: -1
+    mipBias: -100
     wrapU: -1
     wrapV: -1
     wrapW: -1
@@ -51,11 +53,13 @@ TextureImporter:
   spriteTessellationDetail: -1
   textureType: 0
   textureShape: 1
+  singleChannelComponent: 0
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
   platformSettings:
-  - buildTarget: DefaultTexturePlatform
+  - serializedVersion: 2
+    buildTarget: DefaultTexturePlatform
     maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
@@ -65,7 +69,8 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
+  - serializedVersion: 2
+    buildTarget: Standalone
     maxTextureSize: 1024
     resizeAlgorithm: 0
     textureFormat: -1
@@ -80,7 +85,15 @@ TextureImporter:
     sprites: []
     outline: []
     physicsShape: []
+    bones: []
+    spriteID: 
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
   spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/HipParticle/Textures/vmag_tex.png.meta
+++ b/Assets/HipParticle/Textures/vmag_tex.png.meta
@@ -3,10 +3,10 @@ guid: 1fa9bc35760d6428ab432de1ebecf55d
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}
-  serializedVersion: 4
+  serializedVersion: 9
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 0
     linearTexture: 0
     fadeOut: 0
@@ -21,6 +21,8 @@ TextureImporter:
     heightScale: 0.25
     normalMapFilter: 0
   isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -31,7 +33,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 0
     aniso: -1
-    mipBias: -1
+    mipBias: -100
     wrapU: -1
     wrapV: -1
     wrapW: -1
@@ -51,11 +53,13 @@ TextureImporter:
   spriteTessellationDetail: -1
   textureType: 0
   textureShape: 1
+  singleChannelComponent: 0
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
   platformSettings:
-  - buildTarget: DefaultTexturePlatform
+  - serializedVersion: 2
+    buildTarget: DefaultTexturePlatform
     maxTextureSize: 512
     resizeAlgorithm: 0
     textureFormat: -1
@@ -65,7 +69,8 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-  - buildTarget: Standalone
+  - serializedVersion: 2
+    buildTarget: Standalone
     maxTextureSize: 512
     resizeAlgorithm: 0
     textureFormat: -1
@@ -80,7 +85,15 @@ TextureImporter:
     sprites: []
     outline: []
     physicsShape: []
+    bones: []
+    spriteID: 
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
   spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
ワールドスペースでのビルボード生成を行うことでプラットフォーム、シングルパスステレオの有無による違いを最低限に抑え、#2 の問題の根本的解決を図ります。
ついでに

- テクスチャの幅をハードコードせずにUnityの機能を使って取得する
- レンダリング後のアルファチャネル値が正常になるように（VRCのカメラの一部のフィルタ撮影時に影響）
- ミップマップ生成を無効化(LOD0しか使わないのでいらない)

をコミットを分けてしてあります。